### PR TITLE
different viewboxes for 'solid' and 'outline'

### DIFF
--- a/src/icon.tsx
+++ b/src/icon.tsx
@@ -29,7 +29,7 @@ export const Icon: Component<Props> = (props) => {
 
   return (
     <svg
-      viewBox="0 0 24 24"
+      viewBox={internal.path.outline ? "0 0 24 24" : "0 0 20 20"}
       style={{
         fill: internal.path.outline ? "none" : "currentColor",
         stroke: internal.path.outline ? "currentColor" : "none",


### PR DESCRIPTION
from heroicons' homepage:
"Outline - For primary navigation and marketing sections, designed to be rendered at 24x24."
"Solid - For buttons, form elements, and to support text, designed to be rendered at 20x20."