### PR TITLE
fix: incorrect `Props.path.path` type

### DIFF
--- a/src/icon.tsx
+++ b/src/icon.tsx
@@ -5,7 +5,7 @@ interface Props extends JSX.SvgSVGAttributes<SVGSVGElement> {
    * This is the path of the SVG
    */
   path: {
-    path: JSX.Element;
+    path: () => JSX.Element;
     outline?: boolean;
     mini?: boolean;
   };


### PR DESCRIPTION
The generated icon files in the `solid.heroicons` NPM package use the following type:

```
interface {
  path: () => JSX.Element;
  outline?: boolean;
  mini?: boolean;
}
```

For example, `export const academicCap = { path: () => <><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436..."/></>, outline: true, mini: false };
`

But the current definition in the Icon `Props` is `path: JSX.Element`. Defining custom icons as `path: JSX.Element` doesn't work, it needs to be a function.